### PR TITLE
Load past searches

### DIFF
--- a/server/api/index.js
+++ b/server/api/index.js
@@ -1,5 +1,6 @@
 const router = require('express').Router();
 
 router.use('/tweets', require('./tweets'));
+router.use('/searches', require('./searches'));
 
 module.exports = router;

--- a/server/api/searches.js
+++ b/server/api/searches.js
@@ -1,26 +1,11 @@
 const router = require('express').Router();
-const { Tweet, Metadata } = require('../db/index');
-const { adjectivesToWordFrequencies } = require('../twitter/parseTweets');
+const { createSearchArray } = require('../twitter/helperFunctions');
+const { Metadata } = require('../db/index');
 
 // fetch adjective word frequency objects
 router.get('/', (req, res, next) => {
     Metadata.findAll()
-        .then(metadata => metadata.reduce((acc, m) => {
-            if (!acc[m.search_id]) acc[m.search_id] = m.query;
-            return acc;
-        }, {}))
-        .then(searches => res.send(searches))
-        .catch(next);
-})
-
-router.get('/:search_id', (req, res, next) => {
-    Tweet.findAll({
-        where: {
-            search_id: req.params.search_id,
-        },
-    })
-        .then(tweets => adjectivesToWordFrequencies(tweets))
-        .then(adj => res.send(adj))
+        .then(metadata => res.send(createSearchArray(metadata)))
         .catch(next);
 })
 

--- a/server/api/searches.js
+++ b/server/api/searches.js
@@ -1,0 +1,27 @@
+const router = require('express').Router();
+const { Tweet, Metadata } = require('../db/index');
+const { adjectivesToWordFrequencies } = require('../twitter/parseTweets');
+
+// fetch adjective word frequency objects
+router.get('/', (req, res, next) => {
+    Metadata.findAll()
+        .then(metadata => metadata.reduce((acc, m) => {
+            if (!acc[m.search_id]) acc[m.search_id] = m.query;
+            return acc;
+        }, {}))
+        .then(searches => res.send(searches))
+        .catch(next);
+})
+
+router.get('/:search_id', (req, res, next) => {
+    Tweet.findAll({
+        where: {
+            search_id: req.params.search_id,
+        },
+    })
+        .then(tweets => adjectivesToWordFrequencies(tweets))
+        .then(adj => res.send(adj))
+        .catch(next);
+})
+
+module.exports = router;

--- a/server/api/tweets.js
+++ b/server/api/tweets.js
@@ -7,22 +7,35 @@ const {
 const { Tweet, Metadata } = require('../db/index');
 
 // fetch adjective word frequency objects
-router.get('/adjectives/:query', (req, res, next) => {
-  Metadata.findAll({
+// router.get('/adjectives/:query', (req, res, next) => {
+//   Metadata.findAll({
+//     where: {
+//       query: req.params.query,
+//     }
+//   })
+//     .then(metadata => metadata.map(search => search.search_id))
+//     .then(ids => { return ids.length ? Math.max(...ids) : 0 })
+//     .then(search_id => Tweet.findAll({
+//       where: {
+//         search_id,
+//       },
+//     })
+//       .then(tweets => adjectivesToWordFrequencies(tweets))
+//       .then(adj => res.send(adj))
+//       .catch(next));
+// });
+
+// fetch noun word frequency objects
+router.get('/adjectives/:searchId', (req, res, next) => {
+  console.log(req.params.searchId);
+  Tweet.findAll({
     where: {
-      query: req.params.query,
-    }
+      search_id: Number(req.params.searchId),
+    },
   })
-    .then(metadata => metadata.map(search => search.search_id))
-    .then(ids => { return ids.length ? Math.max(...ids) : 0 })
-    .then(search_id => Tweet.findAll({
-      where: {
-        search_id,
-      },
-    })
-      .then(tweets => adjectivesToWordFrequencies(tweets))
-      .then(adj => res.send(adj))
-      .catch(next));
+    .then(tweets => adjectivesToWordFrequencies(tweets))
+    .then(adj => res.send(adj))
+    .catch(next);
 });
 
 // fetch noun word frequency objects
@@ -33,7 +46,7 @@ router.get('/nouns/:query', (req, res, next) => {
     },
   })
     .then(tweets => nounsToWordFrequencies(tweets))
-    .then(adj => res.send(adj))
+    .then(noun => res.send(noun))
     .catch(next);
 });
 
@@ -46,12 +59,12 @@ router.get('/nouns/:query', (req, res, next) => {
 //     .catch(next);
 // });
 
-router.post('/reset', (req, res, next) => {
+router.post('/search', (req, res, next) => {
   Metadata.findAll()
     .then(metadata => metadata.map(search => search.search_id))
     .then(ids => { return ids.length ? Math.max(...ids) : 0 })
     .then(lastSearchId => fetchTweets(req.body.query, 500, lastSearchId)
-      .then(() => res.sendStatus(201)));
+      .then(search_id => res.send(`${search_id}`)));
 })
 
 router.get('/:query', (req, res, next) => {

--- a/server/api/tweets.js
+++ b/server/api/tweets.js
@@ -7,25 +7,6 @@ const {
 const { Tweet, Metadata } = require('../db/index');
 
 // fetch adjective word frequency objects
-// router.get('/adjectives/:query', (req, res, next) => {
-//   Metadata.findAll({
-//     where: {
-//       query: req.params.query,
-//     }
-//   })
-//     .then(metadata => metadata.map(search => search.search_id))
-//     .then(ids => { return ids.length ? Math.max(...ids) : 0 })
-//     .then(search_id => Tweet.findAll({
-//       where: {
-//         search_id,
-//       },
-//     })
-//       .then(tweets => adjectivesToWordFrequencies(tweets))
-//       .then(adj => res.send(adj))
-//       .catch(next));
-// });
-
-// fetch noun word frequency objects
 router.get('/adjectives/:searchId', (req, res, next) => {
   console.log(req.params.searchId);
   Tweet.findAll({
@@ -39,25 +20,16 @@ router.get('/adjectives/:searchId', (req, res, next) => {
 });
 
 // fetch noun word frequency objects
-router.get('/nouns/:query', (req, res, next) => {
+router.get('/nouns/:searchId', (req, res, next) => {
   Tweet.findAll({
     where: {
-      query: req.params.query,
+      search_id: Number(req.params.searchId),
     },
   })
     .then(tweets => nounsToWordFrequencies(tweets))
     .then(noun => res.send(noun))
     .catch(next);
 });
-
-// reset database and fetch 500 tweets
-// router.post('/reset', (req, res, next) => {
-//   Tweet.destroy({ where: {} })
-//   Metadata.destroy({ where: {} })
-//     .then(() => fetchTweets(req.body.query, 500))
-//     .then(() => res.sendStatus(201))
-//     .catch(next);
-// });
 
 router.post('/search', (req, res, next) => {
   Metadata.findAll()

--- a/server/api/tweets.js
+++ b/server/api/tweets.js
@@ -38,21 +38,21 @@ router.get('/nouns/:query', (req, res, next) => {
 });
 
 // reset database and fetch 500 tweets
-router.post('/reset', (req, res, next) => {
-  Tweet.destroy({ where: {} })
-  Metadata.destroy({ where: {} })
-    .then(() => fetchTweets(req.body.query, 500))
-    .then(() => res.sendStatus(201))
-    .catch(next);
-});
-
 // router.post('/reset', (req, res, next) => {
-//   Metadata.findAll()
-//     .then(metadata => metadata.map(search => search.search_id))
-//     .then(ids => { return ids.length ? Math.max(...ids) : 0 })
-//     .then(lastSearchId => fetchTweets(req.body.query, 500, lastSearchId)
-//       .then(() => res.sendStatus(201)));
-// })
+//   Tweet.destroy({ where: {} })
+//   Metadata.destroy({ where: {} })
+//     .then(() => fetchTweets(req.body.query, 500))
+//     .then(() => res.sendStatus(201))
+//     .catch(next);
+// });
+
+router.post('/reset', (req, res, next) => {
+  Metadata.findAll()
+    .then(metadata => metadata.map(search => search.search_id))
+    .then(ids => { return ids.length ? Math.max(...ids) : 0 })
+    .then(lastSearchId => fetchTweets(req.body.query, 500, lastSearchId)
+      .then(() => res.sendStatus(201)));
+})
 
 router.get('/:query', (req, res, next) => {
   Tweet.findAll({

--- a/server/twitter/fetchTweets.js
+++ b/server/twitter/fetchTweets.js
@@ -27,7 +27,7 @@ const getNextMaxId = str => {
 // get next set of tweets and save to database (also save metadata)
 const getTweets = async (q, count, search_id, max_id = null) => {
   const tweets = await client.get('search/tweets', {
-    q: `${q} -filter:retweets`,
+    q: `${q} filter:coordinates`,
     count,
     max_id,
     lang: 'en',
@@ -67,7 +67,6 @@ const getTweets = async (q, count, search_id, max_id = null) => {
 // keep fetching tweets until reach total required number of tweets
 const fetchTweets = async (q, total, lastSearchId) => {
 
-  console.log(lastSearchId);
   const search_id = lastSearchId ? ++lastSearchId : 1;
 
   let metadata = await getTweets(q, 100, search_id);

--- a/server/twitter/fetchTweets.js
+++ b/server/twitter/fetchTweets.js
@@ -27,7 +27,7 @@ const getNextMaxId = str => {
 // get next set of tweets and save to database (also save metadata)
 const getTweets = async (q, count, search_id, max_id = null) => {
   const tweets = await client.get('search/tweets', {
-    q: `${q} filter:coordinates`,
+    q: `${q} -filter:retweets`,
     count,
     max_id,
     lang: 'en',

--- a/server/twitter/fetchTweets.js
+++ b/server/twitter/fetchTweets.js
@@ -78,6 +78,8 @@ const fetchTweets = async (q, total, lastSearchId) => {
     recordCount += metadata[0];
     max_id = metadata[1];
   }
+
+  return (search_id);
 };
 
 module.exports = {

--- a/server/twitter/helperFunctions.js
+++ b/server/twitter/helperFunctions.js
@@ -1,0 +1,19 @@
+
+const createSearchArray = metadata => {
+
+    const searchObj = metadata.reduce((acc, m) => {
+        if (!acc[m.search_id]) acc[m.search_id] = m.query;
+        return acc;
+    }, {});
+
+    return Object.keys(searchObj).map(key => {
+        return {
+            search_id: Number(key),
+            query: searchObj[key],
+        }
+    });
+};
+
+module.exports = {
+    createSearchArray
+}

--- a/src/components/Common/Input.js
+++ b/src/components/Common/Input.js
@@ -10,6 +10,7 @@ import {
 } from '../../reducers/wordcloudReducer';
 import { startLoading } from '../../reducers/loadingReducer';
 import { emptySelectedTweets } from '../../reducers/tweetsReducer';
+import { fetchSearches } from '../../reducers/searchesReducer';
 
 class Input extends Component {
   state = {
@@ -28,7 +29,9 @@ class Input extends Component {
       this.props.startLoading('wordcloudIsLoading');
       axios
         .post('/api/tweets/search', { query: this.state.searchText })
-        .then(search_id => this.props.fetchAdjectiveWordcloudData(search_id.data));
+        .then(search_id => this.props.fetchAdjectiveWordcloudData(search_id.data))
+        .then(() => console.log('serches'))
+        .then(() => this.props.fetchSearches());
       this.props.history.push(`/search/${this.state.searchText}`);
     }
   };
@@ -90,6 +93,7 @@ export default withRouter(
       startLoading,
       resetWordCloud,
       emptySelectedTweets,
+      fetchSearches,
     }
   )(Input)
 );

--- a/src/components/Common/Input.js
+++ b/src/components/Common/Input.js
@@ -27,10 +27,8 @@ class Input extends Component {
       this.props.emptySelectedTweets();
       this.props.startLoading('wordcloudIsLoading');
       axios
-        .post('/api/tweets/reset', { query: this.state.searchText })
-        .then(() =>
-          this.props.fetchAdjectiveWordcloudData(this.state.searchText)
-        );
+        .post('/api/tweets/search', { query: this.state.searchText })
+        .then(search_id => this.props.fetchAdjectiveWordcloudData(search_id.data));
       this.props.history.push(`/search/${this.state.searchText}`);
     }
   };

--- a/src/components/Common/Input.js
+++ b/src/components/Common/Input.js
@@ -30,7 +30,6 @@ class Input extends Component {
       axios
         .post('/api/tweets/search', { query: this.state.searchText })
         .then(search_id => this.props.fetchAdjectiveWordcloudData(search_id.data))
-        .then(() => console.log('serches'))
         .then(() => this.props.fetchSearches());
       this.props.history.push(`/search/${this.state.searchText}`);
     }

--- a/src/components/Navbar/Search.js
+++ b/src/components/Navbar/Search.js
@@ -9,6 +9,7 @@ import SearchIcon from '@material-ui/icons/Search';
 import { fetchAdjectiveWordcloudData, resetWordCloud } from '../../reducers/wordcloudReducer';
 import { startLoading } from '../../reducers/loadingReducer';
 import { emptySelectedTweets } from '../../reducers/tweetsReducer';
+import { fetchSearches } from '../../reducers/searchesReducer';
 
 
 const useStyles = makeStyles(theme => ({
@@ -51,11 +52,12 @@ const Search = ({
   startLoading,
   resetWordCloud,
   emptySelectedTweets,
+  fetchSearches,
 }) => {
   const classes = useStyles();
   const [query, setQuery] = useState('');
-  
-  useEffect(()=> {
+
+  useEffect(() => {
     if (match.params.searchedText) setQuery(match.params.searchedText);
   }, [])
 
@@ -69,10 +71,11 @@ const Search = ({
       resetWordCloud();
       emptySelectedTweets();
       startLoading('wordcloudIsLoading');
-      axios.post('/api/tweets/reset', { query })
-        .then(() => fetchAdjectiveWordcloudData(query));
+      axios.post('/api/tweets/search', { query })
+        .then(search_id => fetchAdjectiveWordcloudData(search_id.data))
+        .then(() => fetchSearches());
       history.push(`/search/${query}`)
-    };
+    }
   };
 
   return (
@@ -83,9 +86,9 @@ const Search = ({
       <InputBase
         placeholder="Search Twitter"
         classes={{
-                root: classes.inputRoot,
-                input: classes.inputInput,
-              }}
+          root: classes.inputRoot,
+          input: classes.inputInput,
+        }}
         inputProps={{ 'aria-label': 'Search' }}
         onChange={handleOnChange}
         value={query}
@@ -100,4 +103,6 @@ export default withRouter(
     startLoading,
     resetWordCloud,
     emptySelectedTweets,
-  })(Search));
+    fetchSearches,
+  })(Search)
+);

--- a/src/components/PastSearches.js
+++ b/src/components/PastSearches.js
@@ -1,0 +1,57 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { selectSearchId } from '../reducers/searchesReducer';
+import { fetchAdjectiveWordcloudData } from '../reducers/wordcloudReducer';
+
+class PastSearches extends Component {
+
+    constructor() {
+        super();
+        this.state = {
+            search_id: 1,
+        }
+    }
+
+    handleSelect = ({ target }) => {
+        this.setState({ search_id: Number(target.value) });
+    }
+
+    handleSubmit = evt => {
+        evt.preventDefault();
+        this.props.selectSearchId(this.state.search_id);
+        this.props.fetchAdjectiveWordcloudData(this.state.search_id);
+    }
+
+    render() {
+        const { searches } = this.props.searches;
+        return (
+            <div >
+                <select name="search_id" onChange={this.handleSelect}>
+                    {searches.map(search => {
+                        return (
+                            <option key={search.search_id} value={search.search_id}>{search.query}</option>
+                        )
+                    })}
+                </select>
+                <button type="submit" onClick={this.handleSubmit}>Update Wordcloud</button>
+            </div >
+        )
+    }
+
+}
+
+const mapStateToProps = ({ searches }) => {
+    return {
+        searches,
+    }
+}
+
+const mapDispatchToProps = dispatch => {
+    return {
+        selectSearchId: search_id => dispatch(selectSearchId(search_id)),
+        fetchAdjectiveWordcloudData: search_id => dispatch(fetchAdjectiveWordcloudData(search_id)),
+    }
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(PastSearches);
+

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -50,6 +50,5 @@ const mapDispatchToProps = dispatch => {
     }
 }
 
-
 export default connect(mapStateToProps, mapDispatchToProps)(Sidebar);
 

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -1,54 +1,14 @@
-import React, { Component } from 'react';
-import { connect } from 'react-redux';
-import { selectSearchId } from '../reducers/searchesReducer';
+import React from 'react';
+import PastSearches from './PastSearches';
 
-class Sidebar extends Component {
+const Sidebar = () => {
 
-    constructor() {
-        super();
-        this.state = {
-            search_id: 1,
-        }
-    }
-
-    handleSelect = ({ target }) => {
-        this.setState({ search_id: Number(target.value) });
-    }
-
-    handleSubmit = evt => {
-        evt.preventDefault();
-        this.props.selectSearchId(this.state.search_id);
-    }
-
-    render() {
-        const { searches } = this.props.searches;
-        return (
-            <div >
-                <select name="search_id" onChange={this.handleSelect}>
-                    {searches.map(search => {
-                        return (
-                            <option key={search.search_id} value={search.search_id}>{search.query}</option>
-                        )
-                    })}
-                </select>
-                <button type="submit" onClick={this.handleSubmit}>Update Wordcloud</button>
-            </div >
-        )
-    }
-
+    return (
+        <div >
+            <PastSearches />
+        </div >
+    )
 }
 
-const mapStateToProps = ({ searches }) => {
-    return {
-        searches,
-    }
-}
-
-const mapDispatchToProps = dispatch => {
-    return {
-        selectSearchId: search_id => dispatch(selectSearchId(search_id)),
-    }
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(Sidebar);
+export default Sidebar;
 

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -1,0 +1,55 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { selectSearchId } from '../reducers/searchesReducer';
+
+class Sidebar extends Component {
+
+    constructor() {
+        super();
+        this.state = {
+            search_id: 1,
+        }
+    }
+
+    handleSelect = ({ target }) => {
+        this.setState({ search_id: Number(target.value) });
+    }
+
+    handleSubmit = evt => {
+        evt.preventDefault();
+        this.props.selectSearchId(this.state.search_id);
+    }
+
+    render() {
+        const { searches } = this.props.searches;
+        return (
+            <div >
+                <select name="search_id" onChange={this.handleSelect}>
+                    {searches.map(search => {
+                        return (
+                            <option key={search.search_id} value={search.search_id}>{search.query}</option>
+                        )
+                    })}
+                </select>
+                <button type="submit" onClick={this.handleSubmit}>Update Wordcloud</button>
+            </div >
+        )
+    }
+
+}
+
+const mapStateToProps = ({ searches }) => {
+    return {
+        searches,
+    }
+}
+
+const mapDispatchToProps = dispatch => {
+    return {
+        selectSearchId: search_id => dispatch(selectSearchId(search_id)),
+    }
+}
+
+
+export default connect(mapStateToProps, mapDispatchToProps)(Sidebar);
+

--- a/src/components/WordCloud/index.js
+++ b/src/components/WordCloud/index.js
@@ -9,6 +9,7 @@ import Loading from '../Common/Loading';
 import Input from '../Common/Input';
 import Message from '../Common/Message';
 import EmbeddedTweets from '../EmbeddedTweets';
+import Sidebar from '../Sidebar';
 
 import { endLoading } from '../../reducers/loadingReducer';
 
@@ -64,6 +65,17 @@ const WordCloud = props => {
         alignItems="center"
         className={classes.root}
       >
+        <Grid
+          item
+          xs={12}
+          sm={6}
+          md={3}
+          xl={2}
+          className={classes.tweetsList}
+          align="center"
+        >
+          <Sidebar />
+        </Grid>
         <Grid
           item
           xs={12}

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -4,6 +4,7 @@ import { tweets } from './tweetsReducer';
 import { user } from './userReducer';
 import { sort } from './sortReducer';
 import { loading } from './loadingReducer';
+import { searches } from './searchesReducer';
 
 const rootReducer = combineReducers({
   wordcloudData,
@@ -11,6 +12,7 @@ const rootReducer = combineReducers({
   tweets,
   sort,
   loading,
+  searches,
 });
 
 export default rootReducer;

--- a/src/reducers/searchesReducer.js
+++ b/src/reducers/searchesReducer.js
@@ -1,0 +1,34 @@
+// ACTION CONSTANTS
+const UPDATE_SEARCHES = 'UPDATE_SEARCHES';
+const SELECT_SEARCH = 'SELECT_SEARCH';
+
+// ACTION CREATORS
+export const updateSearches = searches => ({
+    type: UPDATE_SEARCHES,
+    searches,
+});
+
+export const selectSearchId = search_id => ({
+    type: SELECT_SEARCH,
+    search_id,
+})
+
+// INITIAL STATE
+const initialState = {
+    searches: [{ "search_id": 1, "query": "trump" }, { "search_id": 2, "query": "justine" }],
+    search_id: 1,
+};
+
+// REDUCER
+export const searches = (state = initialState, action) => {
+    switch (action.type) {
+        case UPDATE_SEARCHES: {
+            return { ...state, searches: action.searches };
+        }
+        case SELECT_SEARCH: {
+            return { ...state, search_id: action.search_id };
+        }
+        default:
+            return state;
+    }
+};

--- a/src/reducers/searchesReducer.js
+++ b/src/reducers/searchesReducer.js
@@ -1,4 +1,4 @@
-import axios from "axios";
+import axios from 'axios';
 
 // ACTION CONSTANTS
 const UPDATE_SEARCHES = 'UPDATE_SEARCHES';

--- a/src/reducers/searchesReducer.js
+++ b/src/reducers/searchesReducer.js
@@ -1,3 +1,5 @@
+import axios from "axios";
+
 // ACTION CONSTANTS
 const UPDATE_SEARCHES = 'UPDATE_SEARCHES';
 const SELECT_SEARCH = 'SELECT_SEARCH';
@@ -15,7 +17,7 @@ export const selectSearchId = search_id => ({
 
 // INITIAL STATE
 const initialState = {
-    searches: [{ "search_id": 1, "query": "trump" }, { "search_id": 2, "query": "justine" }],
+    searches: [],
     search_id: 1,
 };
 
@@ -30,5 +32,14 @@ export const searches = (state = initialState, action) => {
         }
         default:
             return state;
+    }
+};
+
+// THUNKS
+export const fetchSearches = () => {
+    return dispatch => {
+        return axios.get('/api/searches/')
+            .then(res => res.data)
+            .then(allSearches => dispatch(updateSearches(allSearches)))
     }
 };

--- a/src/reducers/wordcloudReducer.js
+++ b/src/reducers/wordcloudReducer.js
@@ -63,11 +63,11 @@ export const fetchAdjectiveWordcloudData = search_id => {
 };
 
 // fetch only nouns
-export const fetchNounWordcloudData = word => {
+export const fetchNounWordcloudData = search_id => {
   return dispatch => {
     dispatch(wordcloudDataRequest());
     return axios
-      .get(`/api/tweets/nouns/${word}`)
+      .get(`/api/tweets/nouns/${search_id}`)
       .then(response => response.data)
       .then(wordData => dispatch(wordcloudDataSuccess(wordData)))
       .catch(() => dispatch(wordcloudDataFailure()));

--- a/src/reducers/wordcloudReducer.js
+++ b/src/reducers/wordcloudReducer.js
@@ -51,11 +51,11 @@ export const wordcloudData = (state = initialState, action) => {
 // Thunk
 
 // fetch only adjectives
-export const fetchAdjectiveWordcloudData = word => {
+export const fetchAdjectiveWordcloudData = search_id => {
   return dispatch => {
     dispatch(wordcloudDataRequest());
     return axios
-      .get(`/api/tweets/adjectives/${word}`)
+      .get(`/api/tweets/adjectives/${search_id}`)
       .then(response => response.data)
       .then(wordData => dispatch(wordcloudDataSuccess(wordData)))
       .catch(() => dispatch(wordcloudDataFailure()));


### PR DESCRIPTION
- Ability to load wordclouds for past searches
- Ugly, but it's functional - need to clean it up (makes wordcloud page ugly)
- Changed tweetData fetching so it's dependent on search_id now, not query string
- Updated models to include search_id (can search same thing twice without getting dup results)